### PR TITLE
make docker builds (more) host-OS independent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,13 +23,13 @@ getGoDependencies:
 buildProject:
 	rm -rf releases 
 	mkdir releases
-	gox -output="releases/{{.Dir}}_{{.OS}}_{{.Arch}}/{{.Dir}}" -osarch="linux/amd64 linux/arm windows/amd64 windows/386" -ldflags="-X github.com/mxschmitt/golang-url-shortener/util.ldFlagNodeJS=`node --version` -X github.com/mxschmitt/golang-url-shortener/util.ldFlagCommit=`git rev-parse HEAD` -X github.com/mxschmitt/golang-url-shortener/util.ldFlagYarn=`yarn --version` -X github.com/mxschmitt/golang-url-shortener/util.ldFlagCompilationTime=`date --iso-8601=seconds`"
+	gox -output="releases/{{.Dir}}_{{.OS}}_{{.Arch}}/{{.Dir}}" -osarch="linux/amd64 linux/arm windows/amd64 windows/386" -ldflags="-X github.com/mxschmitt/golang-url-shortener/util.ldFlagNodeJS=`node --version` -X github.com/mxschmitt/golang-url-shortener/util.ldFlagCommit=`git rev-parse HEAD` -X github.com/mxschmitt/golang-url-shortener/util.ldFlagYarn=`yarn --version` -X github.com/mxschmitt/golang-url-shortener/util.ldFlagCompilationTime=`TZ=UTC date +%Y-%m-%dT%H:%M:%S+0000`"
 	find releases -maxdepth 1 -mindepth 1 -type d -exec cp build/config.yaml {} \;
 	find releases -maxdepth 1 -mindepth 1 -type d -exec tar -cvjf {}.tar.bz2 {} \;
 
 buildDockerImage:
 	rm -rf docker_releases 
 	mkdir docker_releases
-	CGO_ENABLED=0 gox -output="docker_releases/{{.Dir}}_{{.OS}}_{{.Arch}}/{{.Dir}}" -osarch="linux/amd64 linux/arm" -ldflags="-X github.com/mxschmitt/golang-url-shortener/util.ldFlagNodeJS=`node --version` -X github.com/mxschmitt/golang-url-shortener/util.ldFlagCommit=`git rev-parse HEAD` -X github.com/mxschmitt/golang-url-shortener/util.ldFlagYarn=`yarn --version` -X github.com/mxschmitt/golang-url-shortener/util.ldFlagCompilationTime=`date --iso-8601=seconds`"
+	CGO_ENABLED=0 gox -output="docker_releases/{{.Dir}}_{{.OS}}_{{.Arch}}/{{.Dir}}" -osarch="linux/amd64 linux/arm" -ldflags="-X github.com/mxschmitt/golang-url-shortener/util.ldFlagNodeJS=`node --version` -X github.com/mxschmitt/golang-url-shortener/util.ldFlagCommit=`git rev-parse HEAD` -X github.com/mxschmitt/golang-url-shortener/util.ldFlagYarn=`yarn --version` -X github.com/mxschmitt/golang-url-shortener/util.ldFlagCompilationTime=`TZ=UTC date +%Y-%m-%dT%H:%M:%S+0000`"
 	docker build -t mxschmitt/golang_url_shortener:arm -f Dockerfile.arm .
 	docker build -t mxschmitt/golang_url_shortener -f Dockerfile.amd64 .


### PR DESCRIPTION
Sadly, `date --iso8601` is a GNU coreutils-ism, and returns an
error on platforms that still ship a more generically posix-esque
`/bin/date`: notably FreeBSD and macOS do not support the flag.

Replace with a standard date formatstring that should be portable
to both Linux macOS.  (And probably Solaris/OpenSolaris/SmartOS
as well?)