### PR TITLE
Add config option to disable log coloration

### DIFF
--- a/build/config.yaml
+++ b/build/config.yaml
@@ -5,6 +5,7 @@ RedisHost: localhost:6379 # If using the redis backend, a host:port combination
 RedisPassword: replace me # if using the redis backend, a conneciton password.
 DataDir: ./data # Contains: the database and the private key
 EnableDebugMode: true # Activates more detailed logging
+EnableColorLogs: true # Enables/disables ANSI color sequences in log output; default is true
 ShortedIDLength: 10 # Length of the random generated ID which is used for new shortened URLs
 AuthBackend: oauth # Can be 'oauth' or 'proxy'
 Google:  # only relevant when using the oauth authbackend

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io/ioutil"
 	"net"
 	"testing"
 	"time"
@@ -9,6 +10,14 @@ import (
 )
 
 func TestInitShortener(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "shorten")
+	if err != nil {
+		t.Fatal(err)
+	}
+	util.Config.DataDir = tmpdir
+	if err = initConfig(); err != nil {
+		t.Fatal(err)
+	}
 	close, err := initShortener()
 	if err != nil {
 		t.Fatalf("could not init shortener: %v", err)

--- a/util/config.go
+++ b/util/config.go
@@ -70,6 +70,7 @@ func ReadInConfig() error {
 	if err := envstruct.ApplyEnvVars(&config, "GUS"); err != nil {
 		return errors.Wrap(err, "could not apply environment configuration")
 	}
+	logrus.Info("Loaded configuration: %v", config)
 	config.DataDir, err = filepath.Abs(config.DataDir)
 	if err != nil {
 		return errors.Wrap(err, "could not get relative data dir path")

--- a/util/config.go
+++ b/util/config.go
@@ -23,6 +23,7 @@ type Configuration struct {
 	AuthBackend     string        `yaml:"AuthBackend" env:"AUTH_BACKEND"`
 	UseSSL          bool          `yaml:"EnableSSL" env:"USE_SSL"`
 	EnableDebugMode bool          `yaml:"EnableDebugMode" env:"ENABLE_DEBUG_MODE"`
+	EnableColorLogs bool          `yaml:"EnableColorLogs" env:"ENABLE_COLOR_LOGS"`
 	ShortedIDLength int           `yaml:"ShortedIDLength" env:"SHORTED_ID_LENGTH"`
 	Google          oAuthConf     `yaml:"Google" env:"GOOGLE"`
 	GitHub          oAuthConf     `yaml:"GitHub" env:"GITHUB"`
@@ -48,6 +49,7 @@ var config = Configuration{
 	DataDir:         "data",
 	Backend:         "boltdb",
 	EnableDebugMode: false,
+	EnableColorLogs: true,
 	UseSSL:          false,
 	ShortedIDLength: 4,
 	AuthBackend:     "oauth",

--- a/util/config.go
+++ b/util/config.go
@@ -43,7 +43,7 @@ type proxyAuthConf struct {
 }
 
 // config contains the default values
-var config = Configuration{
+var Config = Configuration{
 	ListenAddr:      ":8080",
 	BaseURL:         "http://localhost:3000",
 	DataDir:         "data",
@@ -59,7 +59,7 @@ var config = Configuration{
 func ReadInConfig() error {
 	file, err := ioutil.ReadFile("config.yaml")
 	if err == nil {
-		if err := yaml.Unmarshal(file, &config); err != nil {
+		if err := yaml.Unmarshal(file, &Config); err != nil {
 			return errors.Wrap(err, "could not unmarshal yaml file")
 		}
 	} else if !os.IsNotExist(err) {
@@ -67,16 +67,16 @@ func ReadInConfig() error {
 	} else {
 		logrus.Info("No configuration file found, using defaults with environment variable overrides.")
 	}
-	if err := envstruct.ApplyEnvVars(&config, "GUS"); err != nil {
+	if err := envstruct.ApplyEnvVars(&Config, "GUS"); err != nil {
 		return errors.Wrap(err, "could not apply environment configuration")
 	}
-	logrus.Info("Loaded configuration: %v", config)
-	config.DataDir, err = filepath.Abs(config.DataDir)
+	logrus.Info("Loaded configuration: %v", Config)
+	Config.DataDir, err = filepath.Abs(Config.DataDir)
 	if err != nil {
 		return errors.Wrap(err, "could not get relative data dir path")
 	}
-	if _, err = os.Stat(config.DataDir); os.IsNotExist(err) {
-		if err = os.MkdirAll(config.DataDir, 0755); err != nil {
+	if _, err = os.Stat(Config.DataDir); os.IsNotExist(err) {
+		if err = os.MkdirAll(Config.DataDir, 0755); err != nil {
 			return errors.Wrap(err, "could not create config directory")
 		}
 	}
@@ -89,10 +89,10 @@ func (o oAuthConf) Enabled() bool {
 
 // GetConfig returns the configuration from the memory
 func GetConfig() Configuration {
-	return config
+	return Config
 }
 
 // SetConfig sets the configuration into the memory
 func SetConfig(c Configuration) {
-	config = c
+	Config = c
 }

--- a/util/config_test.go
+++ b/util/config_test.go
@@ -8,6 +8,6 @@ func TestReadInConfig(t *testing.T) {
 	if err := ReadInConfig(); err != nil {
 		t.Fatalf("could not read in config file: %v", err)
 	}
-	config := config
+	config := Config
 	config.DataDir = "./test"
 }

--- a/util/private.go
+++ b/util/private.go
@@ -14,7 +14,7 @@ var privateKey []byte
 // CheckForPrivateKey checks if already an private key exists, if not it will
 // be randomly generated and saved as a private.dat file in the data directory
 func CheckForPrivateKey() error {
-	privateDatPath := filepath.Join(config.DataDir, "private.dat")
+	privateDatPath := filepath.Join(Config.DataDir, "private.dat")
 	privateDatContent, err := ioutil.ReadFile(privateDatPath)
 	if err == nil {
 		privateKey = privateDatContent

--- a/util/private_test.go
+++ b/util/private_test.go
@@ -14,7 +14,7 @@ func TestCheckforPrivateKey(t *testing.T) {
 	if GetPrivateKey() == nil {
 		t.Fatalf("private key is nil")
 	}
-	if err := os.RemoveAll(config.DataDir); err != nil {
+	if err := os.RemoveAll(Config.DataDir); err != nil {
 		t.Fatalf("could not remove data dir: %v", err)
 	}
 }


### PR DESCRIPTION
Color logs are great in person, but not so awesome when you're trying
to view them in a log aggregation services e.g. splunk, stackdriver,
ELK, etc.