### PR TITLE
Add option to disable access logging

### DIFF
--- a/build/config.yaml
+++ b/build/config.yaml
@@ -5,6 +5,7 @@ RedisHost: localhost:6379 # If using the redis backend, a host:port combination
 RedisPassword: replace me # if using the redis backend, a conneciton password.
 DataDir: ./data # Contains: the database and the private key
 EnableDebugMode: true # Activates more detailed logging
+EnableAccessLogs: true # Enable GIN access logs (default is true; set to false to disable access logging)
 EnableColorLogs: true # Enables/disables ANSI color sequences in log output; default is true
 ShortedIDLength: 10 # Length of the random generated ID which is used for new shortened URLs
 AuthBackend: oauth # Can be 'oauth' or 'proxy'

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -134,11 +134,15 @@ func (h *Handler) setHandlers() error {
 	if err := h.addTemplatesFromFS([]string{"token.html", "protected.html"}); err != nil {
 		return errors.Wrap(err, "could not add templates from FS")
 	}
-	if !util.GetConfig().EnableDebugMode {
-		// if we are not in debug mode, do not log healthchecks
-		h.engine.Use(Ginrus(logrus.StandardLogger(), time.RFC3339, false, "/ok"))
-	} else {
-		h.engine.Use(Ginrus(logrus.StandardLogger(), time.RFC3339, false))
+	// only do web access logs if enabled
+	if util.GetConfig().EnableAccessLogs {
+		if util.GetConfig().EnableDebugMode {
+			// in debug mode, log everything including healthchecks
+			h.engine.Use(Ginrus(logrus.StandardLogger(), time.RFC3339, false))
+		} else {
+			// if we are not in debug mode, do not log healthchecks
+			h.engine.Use(Ginrus(logrus.StandardLogger(), time.RFC3339, false, "/ok"))
+		}
 	}
 	protected := h.engine.Group("/api/v1/protected")
 	if util.GetConfig().AuthBackend == "oauth" {

--- a/util/config.go
+++ b/util/config.go
@@ -14,21 +14,22 @@ import (
 
 // Configuration are the available config values
 type Configuration struct {
-	ListenAddr      string        `yaml:"ListenAddr" env:"LISTEN_ADDR"`
-	BaseURL         string        `yaml:"BaseURL" env:"BASE_URL"`
-	DataDir         string        `yaml:"DataDir" env:"DATA_DIR"`
-	Backend         string        `yaml:"Backend" env:"BACKEND"`
-	RedisHost       string        `yaml:"RedisHost" env:"REDIS_HOST"`
-	RedisPassword   string        `yaml:"RedisPassword" env:"REDIS_PASSWORD"`
-	AuthBackend     string        `yaml:"AuthBackend" env:"AUTH_BACKEND"`
-	UseSSL          bool          `yaml:"EnableSSL" env:"USE_SSL"`
-	EnableDebugMode bool          `yaml:"EnableDebugMode" env:"ENABLE_DEBUG_MODE"`
-	EnableColorLogs bool          `yaml:"EnableColorLogs" env:"ENABLE_COLOR_LOGS"`
-	ShortedIDLength int           `yaml:"ShortedIDLength" env:"SHORTED_ID_LENGTH"`
-	Google          oAuthConf     `yaml:"Google" env:"GOOGLE"`
-	GitHub          oAuthConf     `yaml:"GitHub" env:"GITHUB"`
-	Microsoft       oAuthConf     `yaml:"Microsoft" env:"MICROSOFT"`
-	Proxy           proxyAuthConf `yaml:"Proxy" env:"PROXY"`
+	ListenAddr       string        `yaml:"ListenAddr" env:"LISTEN_ADDR"`
+	BaseURL          string        `yaml:"BaseURL" env:"BASE_URL"`
+	DataDir          string        `yaml:"DataDir" env:"DATA_DIR"`
+	Backend          string        `yaml:"Backend" env:"BACKEND"`
+	RedisHost        string        `yaml:"RedisHost" env:"REDIS_HOST"`
+	RedisPassword    string        `yaml:"RedisPassword" env:"REDIS_PASSWORD"`
+	AuthBackend      string        `yaml:"AuthBackend" env:"AUTH_BACKEND"`
+	UseSSL           bool          `yaml:"EnableSSL" env:"USE_SSL"`
+	EnableDebugMode  bool          `yaml:"EnableDebugMode" env:"ENABLE_DEBUG_MODE"`
+	EnableAccessLogs bool          `yaml:"EnableAccessLogs" env:"ENABLE_ACCESS_LOGS"`
+	EnableColorLogs  bool          `yaml:"EnableColorLogs" env:"ENABLE_COLOR_LOGS"`
+	ShortedIDLength  int           `yaml:"ShortedIDLength" env:"SHORTED_ID_LENGTH"`
+	Google           oAuthConf     `yaml:"Google" env:"GOOGLE"`
+	GitHub           oAuthConf     `yaml:"GitHub" env:"GITHUB"`
+	Microsoft        oAuthConf     `yaml:"Microsoft" env:"MICROSOFT"`
+	Proxy            proxyAuthConf `yaml:"Proxy" env:"PROXY"`
 }
 
 type oAuthConf struct {
@@ -44,15 +45,16 @@ type proxyAuthConf struct {
 
 // config contains the default values
 var Config = Configuration{
-	ListenAddr:      ":8080",
-	BaseURL:         "http://localhost:3000",
-	DataDir:         "data",
-	Backend:         "boltdb",
-	EnableDebugMode: false,
-	EnableColorLogs: true,
-	UseSSL:          false,
-	ShortedIDLength: 4,
-	AuthBackend:     "oauth",
+	ListenAddr:       ":8080",
+	BaseURL:          "http://localhost:3000",
+	DataDir:          "data",
+	Backend:          "boltdb",
+	EnableDebugMode:  false,
+	EnableAccessLogs: true,
+	EnableColorLogs:  true,
+	UseSSL:           false,
+	ShortedIDLength:  4,
+	AuthBackend:      "oauth",
 }
 
 // ReadInConfig loads the Configuration and other needed folders for further usage


### PR DESCRIPTION
For an internally-facing and/or test/qa deployment, web access logs may
be a waste of stackdriver/cloudwatch quota. :)