### PR TITLE
Clean up redis configuration

### DIFF
--- a/build/config.yaml
+++ b/build/config.yaml
@@ -1,8 +1,6 @@
 ListenAddr: ':8080' # Consists of 'IP:Port', e.g. ':8080' listens on any IP and on Port 8080
 BaseURL: 'http://localhost:3000' # Origin URL, required for the authentication via OAuth
 Backend: boltdb # Can be 'boltdb' or 'redis'
-RedisHost: localhost:6379 # If using the redis backend, a host:port combination
-RedisPassword: replace me # if using the redis backend, a conneciton password.
 DataDir: ./data # Contains: the database and the private key
 EnableDebugMode: true # Activates more detailed logging
 EnableAccessLogs: true # Enable GIN access logs (default is true; set to false to disable access logging)
@@ -22,3 +20,10 @@ Proxy:  # only relevant when using the proxy authbackend
   RequireUserHeader: false # If true, will reject connections that do not have the UserHeader set
   UserHeader: "X-Goog-Authenticated-User-ID" # pull the unique user ID from this header
   DisplayNameHeader: "X-Goog-Authenticated-User-Email" # pull the display naem from this header
+Redis:
+  Host: localhost:6379 # host:port combination; required
+  Password: replace me # redis connection password; optional; default is none
+  Db: 0                # redis index (https://redis.io/commands/select); optional; default is 0
+  MaxRetries: 3        # maximum number of retries for a failed redis command
+  ReadTimeout: 3s      # timeout for read operations; default is 3s. This is a golang time.ParseDuration string
+  WriteTimeout: 3s     # timeout for write operations; default is 3s. This is a golang time.ParseDuration string

--- a/stores/store.go
+++ b/stores/store.go
@@ -44,7 +44,7 @@ func New() (*Store, error) {
 	switch backend := util.GetConfig().Backend; backend {
 	case "redis":
 		conf := util.GetConfig().Redis
-		s, err = redis.New(conf.Host, conf.Password, conf.Db,
+		s, err = redis.New(conf.Host, conf.Password, conf.DB,
 			conf.MaxRetries, conf.ReadTimeout,
 			conf.WriteTimeout)
 	case "boltdb":

--- a/stores/store.go
+++ b/stores/store.go
@@ -43,7 +43,10 @@ func New() (*Store, error) {
 	var s shared.Storage
 	switch backend := util.GetConfig().Backend; backend {
 	case "redis":
-		s, err = redis.New(util.GetConfig().RedisHost, util.GetConfig().RedisPassword)
+		conf := util.GetConfig().Redis
+		s, err = redis.New(conf.Host, conf.Password, conf.Db,
+			conf.MaxRetries, conf.ReadTimeout,
+			conf.WriteTimeout)
 	case "boltdb":
 		s, err = boltdb.New(filepath.Join(util.GetConfig().DataDir, "main.db"))
 	default:

--- a/util/config.go
+++ b/util/config.go
@@ -34,10 +34,10 @@ type Configuration struct {
 type redisConf struct {
 	Host         string `yaml:"Host" env:"REDIS_HOST"`
 	Password     string `yaml:"Password" env:"REDIS_PASSWORD"`
-	Db           int    `yaml:"Db", env:"REDIS_DB"`
-	MaxRetries   int    `yaml:"MaxRetries", env:"REDIS_MAX_RETRIES"`
-	ReadTimeout  string `yaml:"ReadTimeout", env:"REDIS_READ_TIMEOUT"`
-	WriteTimeout string `yaml:"WriteTimeout", env:"REDIS_WRITE_TIMEOUT"`
+	DB           int    `yaml:"DB" env:"REDIS_DB"`
+	MaxRetries   int    `yaml:"MaxRetries" env:"REDIS_MAX_RETRIES"`
+	ReadTimeout  string `yaml:"ReadTimeout" env:"REDIS_READ_TIMEOUT"`
+	WriteTimeout string `yaml:"WriteTimeout" env:"REDIS_WRITE_TIMEOUT"`
 }
 
 type oAuthConf struct {
@@ -66,7 +66,7 @@ var Config = Configuration{
 	Redis: redisConf{
 		Host:         "127.0.0.1:6379",
 		Password:     "",
-		Db:           0,
+		DB:           0,
 		MaxRetries:   3,
 		ReadTimeout:  "3s",
 		WriteTimeout: "3s",

--- a/util/config.go
+++ b/util/config.go
@@ -18,8 +18,6 @@ type Configuration struct {
 	BaseURL          string        `yaml:"BaseURL" env:"BASE_URL"`
 	DataDir          string        `yaml:"DataDir" env:"DATA_DIR"`
 	Backend          string        `yaml:"Backend" env:"BACKEND"`
-	RedisHost        string        `yaml:"RedisHost" env:"REDIS_HOST"`
-	RedisPassword    string        `yaml:"RedisPassword" env:"REDIS_PASSWORD"`
 	AuthBackend      string        `yaml:"AuthBackend" env:"AUTH_BACKEND"`
 	UseSSL           bool          `yaml:"EnableSSL" env:"USE_SSL"`
 	EnableDebugMode  bool          `yaml:"EnableDebugMode" env:"ENABLE_DEBUG_MODE"`
@@ -30,6 +28,16 @@ type Configuration struct {
 	GitHub           oAuthConf     `yaml:"GitHub" env:"GITHUB"`
 	Microsoft        oAuthConf     `yaml:"Microsoft" env:"MICROSOFT"`
 	Proxy            proxyAuthConf `yaml:"Proxy" env:"PROXY"`
+	Redis            redisConf     `yaml:"Redis" env:"REDIS"`
+}
+
+type redisConf struct {
+	Host         string `yaml:"Host" env:"REDIS_HOST"`
+	Password     string `yaml:"Password" env:"REDIS_PASSWORD"`
+	Db           int    `yaml:"Db", env:"REDIS_DB"`
+	MaxRetries   int    `yaml:"MaxRetries", env:"REDIS_MAX_RETRIES"`
+	ReadTimeout  string `yaml:"ReadTimeout", env:"REDIS_READ_TIMEOUT"`
+	WriteTimeout string `yaml:"WriteTimeout", env:"REDIS_WRITE_TIMEOUT"`
 }
 
 type oAuthConf struct {
@@ -55,6 +63,14 @@ var Config = Configuration{
 	UseSSL:           false,
 	ShortedIDLength:  4,
 	AuthBackend:      "oauth",
+	Redis: redisConf{
+		Host:         "127.0.0.1:6379",
+		Password:     "",
+		Db:           0,
+		MaxRetries:   3,
+		ReadTimeout:  "3s",
+		WriteTimeout: "3s",
+	},
 }
 
 // ReadInConfig loads the Configuration and other needed folders for further usage

--- a/util/config.go
+++ b/util/config.go
@@ -65,8 +65,6 @@ var Config = Configuration{
 	AuthBackend:      "oauth",
 	Redis: redisConf{
 		Host:         "127.0.0.1:6379",
-		Password:     "",
-		DB:           0,
 		MaxRetries:   3,
 		ReadTimeout:  "3s",
 		WriteTimeout: "3s",


### PR DESCRIPTION
- put redis configs into their own struct
- put a redisConf struct into the default config so that envstruct
  will populate it
- allow tweaking of retry, db index and read/write timeout settings
- update example config.yaml

This is potentially a breaking change for anyone who's been using
the redis backend already, but maybe that's just me? :)