### PR TITLE
use redis as a session store backend

### DIFF
--- a/config/example.yaml
+++ b/config/example.yaml
@@ -22,9 +22,11 @@ Proxy:  # only relevant when using the proxy authbackend
   UserHeader: "X-Goog-Authenticated-User-ID" # pull the unique user ID from this header
   DisplayNameHeader: "X-Goog-Authenticated-User-Email" # pull the display naem from this header
 Redis:
-  Host: localhost:6379 # host:port combination; required
-  Password: replace me # redis connection password; optional; default is none
-  Db: 0                # redis index (https://redis.io/commands/select); optional; default is 0
-  MaxRetries: 3        # maximum number of retries for a failed redis command
-  ReadTimeout: 3s      # timeout for read operations; default is 3s. This is a golang time.ParseDuration string
-  WriteTimeout: 3s     # timeout for write operations; default is 3s. This is a golang time.ParseDuration string
+  Host: localhost:6379  # host:port combination; required
+  Password: replace me  # redis connection password; optional; default is none
+  Db: 0                 # redis index (https://redis.io/commands/select); optional; default is 0
+  MaxRetries: 3         # maximum number of retries for a failed redis command
+  ReadTimeout: 3s       # timeout for read operations; default is 3s. This is a golang time.ParseDuration string
+  WriteTimeout: 3s      # timeout for write operations; default is 3s. This is a golang time.ParseDuration string
+  SessionDB: 1          # redis session store index (https://redis.io/commands/select); optional; default is 1
+  SharedKey: replace me # redis session store shared key; optional; default is "secret"

--- a/deployments/cloudfoundry/run.sh
+++ b/deployments/cloudfoundry/run.sh
@@ -13,6 +13,7 @@ fi
 if [ "$REDIS" != "" ]; then
     export GUS_REDIS_HOST="$(echo $VCAP_SERVICES | jq -r '.["'$REDIS_SERVICE_NAME'"][0].credentials.host'):$(echo $VCAP_SERVICES | jq -r '.["'$REDIS_SERVICE_NAME'"][0].credentials.port')"
     export GUS_REDIS_PASSWORD="$(echo $VCAP_SERVICES | jq -r '.["'$REDIS_SERVICE_NAME'"][0].credentials.password')"
+    export GUS_REDIS_SHARED_KEY=$GUS_REDIS_PASSWORD
 fi
 
 echo "#### Starting golang-url-shortener..."

--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -17,10 +17,10 @@ import (
 )
 
 func (h *Handler) initOAuth() {
-	// use redis as the session store if it is configured
+	// use redis as the session store if it is configured. using redis db '1' to isolate session keys from everything else
 	switch backend := util.GetConfig().Backend; backend {
 	case "redis":
-		store, _ := redis.NewStoreWithDB(10, "tcp", util.GetConfig().Redis.Host, util.GetConfig().Redis.Password, "1", []byte("secret"))
+		store, _ := redis.NewStoreWithDB(10, "tcp", util.GetConfig().Redis.Host, util.GetConfig().Redis.Password, "1", util.GetPrivateKey())
 		h.engine.Use(sessions.Sessions("backend", store))
 	default:
 		h.engine.Use(sessions.Sessions("backend", cookie.NewStore(util.GetPrivateKey())))
@@ -47,14 +47,14 @@ func (h *Handler) initOAuth() {
 
 // initProxyAuth intializes data structures for proxy authentication mode
 func (h *Handler) initProxyAuth() {
-	// use redis as the session store if it is configured
+	// use redis as the session store if it is configured. using redis db '1' to isolate session keys from everything else
 	switch backend := util.GetConfig().Backend; backend {
 	case "redis":
-		store, _ := redis.NewStoreWithDB(10, "tcp", util.GetConfig().Redis.Host, util.GetConfig().Redis.Password, "1", []byte("secret"))
+		store, _ := redis.NewStoreWithDB(10, "tcp", util.GetConfig().Redis.Host, util.GetConfig().Redis.Password, "1", util.GetPrivateKey())
 		h.engine.Use(sessions.Sessions("backend", store))
 	default:
 		h.engine.Use(sessions.Sessions("backend", cookie.NewStore(util.GetPrivateKey())))
-	}	
+	}
 	h.providers = []string{}
 	h.providers = append(h.providers, "proxy")
 	h.engine.POST("/api/v1/auth/check", h.handleAuthCheck)

--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -9,7 +9,9 @@ import (
 	"github.com/sirupsen/logrus"
 
 	jwt "github.com/dgrijalva/jwt-go"
-	"github.com/gin-gonic/contrib/sessions"
+	"github.com/gin-contrib/sessions"
+	"github.com/gin-contrib/sessions/cookie"
+	"github.com/gin-contrib/sessions/redis"
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
 )
@@ -18,10 +20,10 @@ func (h *Handler) initOAuth() {
 	// use redis as the session store if it is configured
 	switch backend := util.GetConfig().Backend; backend {
 	case "redis":
-		store, _ := sessions.NewRedisStore(10, "tcp", util.GetConfig().Redis.Host, util.GetConfig().Redis.Password, []byte("secret"))
+		store, _ := redis.NewStoreWithDB(10, "tcp", util.GetConfig().Redis.Host, util.GetConfig().Redis.Password, "1", []byte("secret"))
 		h.engine.Use(sessions.Sessions("backend", store))
 	default:
-		h.engine.Use(sessions.Sessions("backend", sessions.NewCookieStore(util.GetPrivateKey())))
+		h.engine.Use(sessions.Sessions("backend", cookie.NewStore(util.GetPrivateKey())))
 	}
 	h.providers = []string{}
 	google := util.GetConfig().Google
@@ -48,10 +50,10 @@ func (h *Handler) initProxyAuth() {
 	// use redis as the session store if it is configured
 	switch backend := util.GetConfig().Backend; backend {
 	case "redis":
-		store, _ := sessions.NewRedisStore(10, "tcp", util.GetConfig().Redis.Host, util.GetConfig().Redis.Password, []byte("secret"))
+		store, _ := redis.NewStoreWithDB(10, "tcp", util.GetConfig().Redis.Host, util.GetConfig().Redis.Password, "1", []byte("secret"))
 		h.engine.Use(sessions.Sessions("backend", store))
 	default:
-		h.engine.Use(sessions.Sessions("backend", sessions.NewCookieStore(util.GetPrivateKey())))
+		h.engine.Use(sessions.Sessions("backend", cookie.NewStore(util.GetPrivateKey())))
 	}	
 	h.providers = []string{}
 	h.providers = append(h.providers, "proxy")

--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -17,10 +17,10 @@ import (
 )
 
 func (h *Handler) initOAuth() {
-	// use redis as the session store if it is configured. using redis db '1' to isolate session keys from everything else
 	switch backend := util.GetConfig().Backend; backend {
+	// use redis as the session store if it is configured
 	case "redis":
-		store, _ := redis.NewStoreWithDB(10, "tcp", util.GetConfig().Redis.Host, util.GetConfig().Redis.Password, "1", util.GetPrivateKey())
+		store, _ := redis.NewStoreWithDB(10, "tcp", util.GetConfig().Redis.Host, util.GetConfig().Redis.Password, util.GetConfig().Redis.SessionDB, util.GetPrivateKey())
 		h.engine.Use(sessions.Sessions("backend", store))
 	default:
 		h.engine.Use(sessions.Sessions("backend", cookie.NewStore(util.GetPrivateKey())))
@@ -47,10 +47,10 @@ func (h *Handler) initOAuth() {
 
 // initProxyAuth intializes data structures for proxy authentication mode
 func (h *Handler) initProxyAuth() {
-	// use redis as the session store if it is configured. using redis db '1' to isolate session keys from everything else
 	switch backend := util.GetConfig().Backend; backend {
+	// use redis as the session store if it is configured
 	case "redis":
-		store, _ := redis.NewStoreWithDB(10, "tcp", util.GetConfig().Redis.Host, util.GetConfig().Redis.Password, "1", util.GetPrivateKey())
+		store, _ := redis.NewStoreWithDB(10, "tcp", util.GetConfig().Redis.Host, util.GetConfig().Redis.Password, util.GetConfig().Redis.SessionDB, util.GetPrivateKey())
 		h.engine.Use(sessions.Sessions("backend", store))
 	default:
 		h.engine.Use(sessions.Sessions("backend", cookie.NewStore(util.GetPrivateKey())))

--- a/internal/handlers/auth/auth.go
+++ b/internal/handlers/auth/auth.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
-	"github.com/gin-gonic/contrib/sessions"
+	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
 	"github.com/mxschmitt/golang-url-shortener/internal/util"
 	"github.com/pkg/errors"

--- a/internal/util/config.go
+++ b/internal/util/config.go
@@ -52,7 +52,7 @@ type proxyAuthConf struct {
 	DisplayNameHeader string `yaml:"DisplayNameHeader" env:"DISPLAY_NAME_HEADER"`
 }
 
-// config contains the default values
+// Config contains the default values
 var Config = Configuration{
 	ListenAddr:       ":8080",
 	BaseURL:          "http://localhost:3000",

--- a/internal/util/config.go
+++ b/internal/util/config.go
@@ -14,21 +14,22 @@ import (
 
 // Configuration are the available config values
 type Configuration struct {
-	ListenAddr       string        `yaml:"ListenAddr" env:"LISTEN_ADDR"`
-	BaseURL          string        `yaml:"BaseURL" env:"BASE_URL"`
-	DataDir          string        `yaml:"DataDir" env:"DATA_DIR"`
-	Backend          string        `yaml:"Backend" env:"BACKEND"`
-	AuthBackend      string        `yaml:"AuthBackend" env:"AUTH_BACKEND"`
-	UseSSL           bool          `yaml:"EnableSSL" env:"USE_SSL"`
-	EnableDebugMode  bool          `yaml:"EnableDebugMode" env:"ENABLE_DEBUG_MODE"`
-	EnableAccessLogs bool          `yaml:"EnableAccessLogs" env:"ENABLE_ACCESS_LOGS"`
-	EnableColorLogs  bool          `yaml:"EnableColorLogs" env:"ENABLE_COLOR_LOGS"`
-	ShortedIDLength  int           `yaml:"ShortedIDLength" env:"SHORTED_ID_LENGTH"`
-	Google           oAuthConf     `yaml:"Google" env:"GOOGLE"`
-	GitHub           oAuthConf     `yaml:"GitHub" env:"GITHUB"`
-	Microsoft        oAuthConf     `yaml:"Microsoft" env:"MICROSOFT"`
-	Proxy            proxyAuthConf `yaml:"Proxy" env:"PROXY"`
-	Redis            redisConf     `yaml:"Redis" env:"REDIS"`
+	ListenAddr        string        `yaml:"ListenAddr" env:"LISTEN_ADDR"`
+	BaseURL           string        `yaml:"BaseURL" env:"BASE_URL"`
+	DataDir           string        `yaml:"DataDir" env:"DATA_DIR"`
+	Backend           string        `yaml:"Backend" env:"BACKEND"`
+	AuthBackend       string        `yaml:"AuthBackend" env:"AUTH_BACKEND"`
+	UseSSL            bool          `yaml:"EnableSSL" env:"USE_SSL"`
+	EnableDebugMode   bool          `yaml:"EnableDebugMode" env:"ENABLE_DEBUG_MODE"`
+	EnableAccessLogs  bool          `yaml:"EnableAccessLogs" env:"ENABLE_ACCESS_LOGS"`
+	EnableColorLogs   bool          `yaml:"EnableColorLogs" env:"ENABLE_COLOR_LOGS"`
+	ShortedIDLength   int           `yaml:"ShortedIDLength" env:"SHORTED_ID_LENGTH"`
+	Google            oAuthConf     `yaml:"Google" env:"GOOGLE"`
+	GitHub            oAuthConf     `yaml:"GitHub" env:"GITHUB"`
+	GitHubEndpointURL string        `yaml:"GitHubEndPointURL" env:"GITHUB_ENDPOINT_URL"`
+	Microsoft         oAuthConf     `yaml:"Microsoft" env:"MICROSOFT"`
+	Proxy             proxyAuthConf `yaml:"Proxy" env:"PROXY"`
+	Redis             redisConf     `yaml:"Redis" env:"REDIS"`
 }
 
 type redisConf struct {

--- a/internal/util/config.go
+++ b/internal/util/config.go
@@ -38,6 +38,8 @@ type redisConf struct {
 	MaxRetries   int    `yaml:"MaxRetries" env:"MAX_RETRIES"`
 	ReadTimeout  string `yaml:"ReadTimeout" env:"READ_TIMEOUT"`
 	WriteTimeout string `yaml:"WriteTimeout" env:"WRITE_TIMEOUT"`
+	SessionDB    string `yaml:"SessionDB" env:"SESSION_DB"`
+	SharedKey    string `yaml:"SharedKey" env:"SHARED_KEY"`
 }
 
 type oAuthConf struct {
@@ -69,6 +71,8 @@ var Config = Configuration{
 		MaxRetries:   3,
 		ReadTimeout:  "3s",
 		WriteTimeout: "3s",
+		SessionDB:    "1",
+		SharedKey:    "secret",
 	},
 }
 

--- a/internal/util/config.go
+++ b/internal/util/config.go
@@ -14,22 +14,21 @@ import (
 
 // Configuration are the available config values
 type Configuration struct {
-	ListenAddr        string        `yaml:"ListenAddr" env:"LISTEN_ADDR"`
-	BaseURL           string        `yaml:"BaseURL" env:"BASE_URL"`
-	DataDir           string        `yaml:"DataDir" env:"DATA_DIR"`
-	Backend           string        `yaml:"Backend" env:"BACKEND"`
-	AuthBackend       string        `yaml:"AuthBackend" env:"AUTH_BACKEND"`
-	UseSSL            bool          `yaml:"EnableSSL" env:"USE_SSL"`
-	EnableDebugMode   bool          `yaml:"EnableDebugMode" env:"ENABLE_DEBUG_MODE"`
-	EnableAccessLogs  bool          `yaml:"EnableAccessLogs" env:"ENABLE_ACCESS_LOGS"`
-	EnableColorLogs   bool          `yaml:"EnableColorLogs" env:"ENABLE_COLOR_LOGS"`
-	ShortedIDLength   int           `yaml:"ShortedIDLength" env:"SHORTED_ID_LENGTH"`
-	Google            oAuthConf     `yaml:"Google" env:"GOOGLE"`
-	GitHub            oAuthConf     `yaml:"GitHub" env:"GITHUB"`
-	GitHubEndpointURL string        `yaml:"GitHubEndPointURL" env:"GITHUB_ENDPOINT_URL"`
-	Microsoft         oAuthConf     `yaml:"Microsoft" env:"MICROSOFT"`
-	Proxy             proxyAuthConf `yaml:"Proxy" env:"PROXY"`
-	Redis             redisConf     `yaml:"Redis" env:"REDIS"`
+	ListenAddr       string        `yaml:"ListenAddr" env:"LISTEN_ADDR"`
+	BaseURL          string        `yaml:"BaseURL" env:"BASE_URL"`
+	DataDir          string        `yaml:"DataDir" env:"DATA_DIR"`
+	Backend          string        `yaml:"Backend" env:"BACKEND"`
+	AuthBackend      string        `yaml:"AuthBackend" env:"AUTH_BACKEND"`
+	UseSSL           bool          `yaml:"EnableSSL" env:"USE_SSL"`
+	EnableDebugMode  bool          `yaml:"EnableDebugMode" env:"ENABLE_DEBUG_MODE"`
+	EnableAccessLogs bool          `yaml:"EnableAccessLogs" env:"ENABLE_ACCESS_LOGS"`
+	EnableColorLogs  bool          `yaml:"EnableColorLogs" env:"ENABLE_COLOR_LOGS"`
+	ShortedIDLength  int           `yaml:"ShortedIDLength" env:"SHORTED_ID_LENGTH"`
+	Google           oAuthConf     `yaml:"Google" env:"GOOGLE"`
+	GitHub           oAuthConf     `yaml:"GitHub" env:"GITHUB"`
+	Microsoft        oAuthConf     `yaml:"Microsoft" env:"MICROSOFT"`
+	Proxy            proxyAuthConf `yaml:"Proxy" env:"PROXY"`
+	Redis            redisConf     `yaml:"Redis" env:"REDIS"`
 }
 
 type redisConf struct {

--- a/internal/util/private.go
+++ b/internal/util/private.go
@@ -35,9 +35,11 @@ func CheckForPrivateKey() error {
 
 // GetPrivateKey returns the private key
 func GetPrivateKey() []byte {
-	// return privateKey
-	// returning a static value seems to be required for multiple instances to work with redis as a session store
-	// this doesn't seem like a good pattern
-	return []byte("secret")
-
+	// if using redis as a backend, always return the same static key
+	switch backend := GetConfig().Backend; backend {
+	case "redis":
+		return []byte("secret")
+	default:
+		return privateKey
+	}
 }

--- a/internal/util/private.go
+++ b/internal/util/private.go
@@ -35,10 +35,9 @@ func CheckForPrivateKey() error {
 
 // GetPrivateKey returns the private key
 func GetPrivateKey() []byte {
-	// if using redis as a backend, always return the same static key
 	switch backend := GetConfig().Backend; backend {
 	case "redis":
-		return []byte("secret")
+		return []byte(GetConfig().Redis.SharedKey)
 	default:
 		return privateKey
 	}

--- a/internal/util/private.go
+++ b/internal/util/private.go
@@ -35,5 +35,9 @@ func CheckForPrivateKey() error {
 
 // GetPrivateKey returns the private key
 func GetPrivateKey() []byte {
-	return privateKey
+	// return privateKey
+	// returning a static value seems to be required for multiple instances to work with redis as a session store
+	// this doesn't seem like a good pattern
+	return []byte("secret")
+
 }


### PR DESCRIPTION
See #117 for some background and context

**What is this PR for?** . This PR is to enable support for using redis as the backing store for session information instead of in-memory or local-filesystem database cookie session storage.  The reason for this is to enable multi-headed/multi-instance execution of the app in a way that does not fail with errors due to different runtimes handling different requests.

* There are two new configuration items present for redis:
   1. `SessionDB`: The redis 'database' index to use for holding on to session data.  The default is **1**. To keep things separated, this should be different than the application redis database index (default is **0**).  This is optional.
   1. `SharedKey`: The token/key used to encode the session information stored in redis. This needs to be the same for all instances of the app sharing the same redis store.  The default value is **secret**.  This is optional.
* The [gin sessions library](https://github.com/gin-gonic/contrib/tree/master/sessions) is upgraded to the [current version](https://github.com/gin-contrib/sessions) to avoid continuing to use the older deprecated version
* If the backend is set to redis, it will be used as the session store automatically
* The cloudfoundry deployment config is updated to leverage the redis database password as the shared key, by default