### PR TITLE
[WIP] - Admin view to view _all_ entries

### DIFF
--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -161,6 +161,7 @@ func (h *Handler) setHandlers() error {
 	protected.POST("/create", h.handleCreate)
 	protected.POST("/lookup", h.handleLookup)
 	protected.GET("/recent", h.handleRecent)
+	protected.GET("/admin", h.handleAdmin)
 	protected.POST("/visitors", h.handleGetVisitors)
 
 	h.engine.GET("/api/v1/info", h.handleInfo)

--- a/internal/stores/redis/redis.go
+++ b/internal/stores/redis/redis.go
@@ -303,12 +303,8 @@ func (r *Store) GetAllUserEntries() (map[string]shared.Entry, error) {
 	users := r.c.Keys(userToEntriesPrefix + "*")
 	for _, v := range users.Val() {
 		logrus.Debugf("got userEntry: %s", v)
-		// user, err := r.GetEntryByID(string(v))
-
 		key := v
 		result := r.c.SMembers(key)
-		// result := r.c.Keys(entryPathPrefix + user)
-
 		if result.Err() != nil {
 			msg := fmt.Sprintf("Could not fetch set of entries for user '%s': %v", key, result.Err())
 			logrus.Errorf(msg)

--- a/internal/stores/redis/redis.go
+++ b/internal/stores/redis/redis.go
@@ -274,7 +274,32 @@ func (r *Store) GetEntryByID(id string) (*shared.Entry, error) {
 func (r *Store) GetUserEntries(userIdentifier string) (map[string]shared.Entry, error) {
 	logrus.Debugf("Getting all entries for user %s", userIdentifier)
 	entries := map[string]shared.Entry{}
+	key := userToEntriesPrefix + userIdentifier
+	result := r.c.SMembers(key)
+	if result.Err() != nil {
+		msg := fmt.Sprintf("Could not fetch set of entries for user '%s': %v", userIdentifier, result.Err())
+		logrus.Errorf(msg)
+		return nil, errors.Wrap(result.Err(), msg)
+	}
+	for _, v := range result.Val() {
+		logrus.Debugf("got entry: %s", v)
+		entry, err := r.GetEntryByID(string(v))
+		if err != nil {
+			msg := fmt.Sprintf("Could not get entry '%s': %s", v, err)
+			logrus.Warn(msg)
+		} else {
+			entries[string(v)] = *entry
+		}
+	}
+	logrus.Debugf("all out of entries")
+	return entries, nil
+}
 
+// GetAllUserEntries returns all entries for all users, in the
+// form of a map of path->shared.Entry
+func (r *Store) GetAllUserEntries() (map[string]shared.Entry, error) {
+	logrus.Debugf("Getting all entries for all users")
+	entries := map[string]shared.Entry{}
 	users := r.c.Keys(userToEntriesPrefix + "*")
 	for _, v := range users.Val() {
 		logrus.Debugf("got userEntry: %s", v)
@@ -285,7 +310,7 @@ func (r *Store) GetUserEntries(userIdentifier string) (map[string]shared.Entry, 
 		// result := r.c.Keys(entryPathPrefix + user)
 
 		if result.Err() != nil {
-			msg := fmt.Sprintf("Could not fetch set of entries for user '%s': %v", userIdentifier, result.Err())
+			msg := fmt.Sprintf("Could not fetch set of entries for user '%s': %v", key, result.Err())
 			logrus.Errorf(msg)
 			return nil, errors.Wrap(result.Err(), msg)
 		}

--- a/internal/stores/shared/shared.go
+++ b/internal/stores/shared/shared.go
@@ -14,6 +14,7 @@ type Storage interface {
 	IncreaseVisitCounter(string) error
 	CreateEntry(Entry, string, string) error
 	GetUserEntries(string) (map[string]Entry, error)
+	GetAllUserEntries() (map[string]Entry, error)
 	RegisterVisitor(string, string, Visitor) error
 	Close() error
 }

--- a/internal/stores/store.go
+++ b/internal/stores/store.go
@@ -157,6 +157,15 @@ func (s *Store) GetUserEntries(oAuthProvider, oAuthID string) (map[string]shared
 	return entries, nil
 }
 
+// GetAllUserEntries returns all the shorted URL entries of an user
+func (s *Store) GetAllUserEntries() (map[string]shared.Entry, error) {
+	entries, err := s.storage.GetAllUserEntries()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get all entries")
+	}
+	return entries, nil
+}
+
 func getUserIdentifier(oAuthProvider, oAuthID string) string {
 	return oAuthProvider + oAuthID
 }

--- a/web/src/Admin/Admin.js
+++ b/web/src/Admin/Admin.js
@@ -1,0 +1,88 @@
+import React, { Component } from 'react'
+import { Container, Button, Icon } from 'semantic-ui-react'
+import Moment from 'react-moment';
+import ReactTable from 'react-table'
+import 'react-table/react-table.css'
+
+import util from '../util/util'
+
+export default class AllEntriesComponent extends Component {
+    state = {
+        allEntries: []
+    }
+
+    componentDidMount() {
+        this.getAllURLs()
+    }
+
+    getAllURLs = () => {
+        util.getAllURLs(allEntries => {
+            let parsed = [];
+            for (let key in allEntries) {
+                allEntries[key].ID = key;
+                parsed.push(allEntries[key]);
+            }
+            this.setState({ allEntries: parsed })
+        })
+    }
+
+    onRowClick(id) {
+        this.props.history.push(`/visitors/${id}`)
+    }
+
+    onEntryDeletion(deletionURL) {
+        util.deleteEntry(deletionURL, this.getAllURLs)
+    }
+
+    render() {
+        const { allEntries } = this.state
+
+        const columns = [{
+            Header: 'Original URL',
+            accessor: "Public.URL"
+        }, {
+            Header: 'Created',
+            accessor: 'Public.CreatedOn',
+            Cell: props => <Moment fromNow>{props.value}</Moment>
+        }, {
+            Header: 'Short URL',
+            accessor: "ID",
+            Cell: props => `${window.location.origin}/${props.value}`
+        }, {
+            Header: 'Visitor count',
+            accessor: "Public.VisitCount"
+
+        }, {
+            Header: 'Delete',
+            accessor: 'DeletionURL',
+            Cell: props => <Button animated='vertical' onClick={this.onEntryDeletion.bind(this, props.value)}>
+                <Button.Content hidden>Delete</Button.Content>
+                <Button.Content visible>
+                    <Icon name='trash' />
+                </Button.Content>
+            </Button>,
+            style: { textAlign: "center" }
+        }]
+
+        return (
+            <Container>
+                <ReactTable data={allEntries} columns={columns} getTdProps={(state, rowInfo, column, instance) => {
+                    return {
+                        onClick: (e, handleOriginal) => {
+                            if (handleOriginal) {
+                                handleOriginal()
+                            }
+                            if (!rowInfo) {
+                                return
+                            }
+                            if (column.id === "DeletionURL") {
+                                return
+                            }
+                            this.onRowClick(rowInfo.row.ID)
+                        }
+                    }
+                }} />
+            </Container>
+        )
+    }
+}

--- a/web/src/Admin/Admin.js
+++ b/web/src/Admin/Admin.js
@@ -8,19 +8,25 @@ import util from '../util/util'
 
 export default class AllEntriesComponent extends Component {
     state = {
-        allEntries: []
+        allEntries: [],
+        displayURL: window.location.origin
     }
 
     componentDidMount() {
         this.getAllURLs()
+        fetch("/displayurl")
+        .then(response => response.json())
+        .then(data => this.setState({displayURL: data}));
     }
 
     getAllURLs = () => {
         util.getAllURLs(allEntries => {
             let parsed = [];
             for (let key in allEntries) {
-                allEntries[key].ID = key;
-                parsed.push(allEntries[key]);
+                if ({}.hasOwnProperty.call(allEntries, key)) {
+                    allEntries[key].ID = key;
+                    parsed.push(allEntries[key]);
+                }
             }
             this.setState({ allEntries: parsed })
         })
@@ -47,7 +53,7 @@ export default class AllEntriesComponent extends Component {
         }, {
             Header: 'Short URL',
             accessor: "ID",
-            Cell: props => `${window.location.origin}/${props.value}`
+            Cell: props => `${this.state.displayURL}/${props.value}`
         }, {
             Header: 'Visitor count',
             accessor: "Public.VisitCount"

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -11,6 +11,7 @@ import Home from './Home/Home'
 import ShareX from './ShareX/ShareX'
 import Lookup from './Lookup/Lookup'
 import Recent from './Recent/Recent'
+import Admin from './Admin/Admin'
 import Visitors from './Visitors/Visitors'
 
 import util from './util/util'
@@ -186,6 +187,7 @@ export default class BaseComponent extends Component {
                     <Route path="/ShareX" component={ShareX} />
                     <Route path="/Lookup" component={Lookup} />
                     <Route path="/recent" component={Recent} />
+                    <Route path="/admin" component={Admin} />
                     <Route path="/visitors/:id" component={Visitors} />
                 </Container>
             </HashRouter>

--- a/web/src/util/util.js
+++ b/web/src/util/util.js
@@ -61,4 +61,16 @@ export default class UtilHelper {
             .then(res => res.ok ? res.json() : Promise.reject(res.json()))
             .catch(e => this._reportError(e, "getDisplayURL"))
     }
+    static getAllURLs(cbSucc) {
+        fetch('/api/v1/protected/admin', {
+            credentials: "include",
+            headers: {
+                'Authorization': window.localStorage.getItem('token'),
+                'Content-Type': 'application/json'
+            }
+        })
+            .then(res => res.ok ? res.json() : Promise.reject(res.json()))
+            .then(res => cbSucc ? cbSucc(res) : null)
+            .catch(e => this._reportError(e, "recent"))
+    }
 }


### PR DESCRIPTION
This PR is a work in progress.

**What is the purpose of this PR?** . This will enable an 'admin view' such that it is possible to view and delete any of the entries in the system, even if you did not create them.

* The approach taken is to create a whole new page (`/admin`) that will work very much like the `/recent` page but will display all entries for all users.
* There is currently no restriction on who can view this page as long as they are authenticated with the backend OAuth provider

Some form of protection needs to be added to this - I'm thinking a 'admin password' that would need to be entered by the user would be compared with a configured password.  If they match, then allow the user to load the page.  I'm not sure how best to go about implementing this part (or open to other ideas as well)

An alternative approach could be to extend the `/recent` page with a button or some other control that would present the user with a password prompt, and if successful, would re-render the page with all the entries instead of just the entries associated with the user logged-in.

Would love some feedback/suggestions, as not having the ability to see all entries is a limiting factor  right now