### PR TITLE
clarifying cf manifest and adding to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,9 @@ debug.test
 /releases
 /docker_releases
 data
+
+/deployments/cloudfoundry
+!/deployments/cloudfoundry/README.md
+!/deployments/cloudfoundry/config.yaml
+!/deployments/cloudfoundry/manifest-example.yml
+!/deployments/cloudfoundry/run.sh

--- a/deployments/cloudfoundry/manifest-example.yml
+++ b/deployments/cloudfoundry/manifest-example.yml
@@ -3,7 +3,7 @@ applications:
   buildpack: binary_buildpack
   memory: 64m
   command: './run.sh'
-  instances: 1 # should not be more than 1 due to session handling
+  instances: 1 # only use > 1 if you are using redis as the backend
   health-check-type: http
   health-check-http-endpoint: /ok
   # if you use any marketplace or cups services, define the binding here


### PR DESCRIPTION
Small update to:

* git ignore everything in `deployment/cloudfoundry/` except for the default files
* clarify `manifest-example.yml` that you can use > 1 instances with a redis backend now that #119 is merged